### PR TITLE
Dscrobonia/aws secret access key

### DIFF
--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -19,8 +19,12 @@ class AWSKeyDetector(RegexBasedDetector):
     """Scans for AWS keys."""
     secret_type = 'AWS Access Key'
 
+    # This regex checks for the AWS access-key-id, not the secret-access-key.
+    # Removing as the secret-access-key is real culprit we care about.
+    # Ideally we could use both to determine confidence.
+    # re.compile(r'AKIA[0-9A-Z]{16}'),
     denylist = (
-        re.compile(r'AKIA[0-9A-Z]{16}'),
+        re.compile(r'(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])'), # regex for secret-access-key
     )
 
     @classproperty

--- a/detect_secrets/plugins/aws.py
+++ b/detect_secrets/plugins/aws.py
@@ -17,14 +17,10 @@ from detect_secrets.plugins.base import RegexBasedDetector
 
 class AWSKeyDetector(RegexBasedDetector):
     """Scans for AWS keys."""
-    secret_type = 'AWS Access Key'
+    secret_type = 'AWS Access Key ID'
 
-    # This regex checks for the AWS access-key-id, not the secret-access-key.
-    # Removing as the secret-access-key is real culprit we care about.
-    # Ideally we could use both to determine confidence.
-    # re.compile(r'AKIA[0-9A-Z]{16}'),
     denylist = (
-        re.compile(r'(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])'), # regex for secret-access-key
+        re.compile(r'AKIA[0-9A-Z]{16}'),
     )
 
     @classproperty

--- a/detect_secrets/plugins/aws_secret_access_key.py
+++ b/detect_secrets/plugins/aws_secret_access_key.py
@@ -1,0 +1,19 @@
+from detect_secrets.plugins.base import RegexBasedDetector
+
+
+class AWSSSecretAccessKeyDetector(RegexBasedDetector):
+    """Scans for AWS secret-access-key."""
+
+    secret_type = 'AWS Secret Access Key'
+
+    prefix = r'*'
+    aws_secret_keywords = r'.*(?:aws|secret|access|key).*'
+    secret_pattern = r'(?<![A-Za-z0-9/+])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])'
+
+    denylist = [
+        RegexBasedDetector.assign_regex_generator(
+            prefix_regex=prefix,
+            secret_keyword_regex=aws_secret_keywords,
+            secret_regex=secret_pattern,
+        ),
+    ]

--- a/tests/plugins/aws_secret_access_key_test.py
+++ b/tests/plugins/aws_secret_access_key_test.py
@@ -1,0 +1,25 @@
+import pytest
+
+from detect_secrets.plugins.aws_secret_access_key import AWSSSecretAccessKeyDetector
+
+
+class TestAWSSecretAccessKeyDetector:
+
+    @pytest.mark.parametrize(
+        'payload, should_flag',
+        [
+            ('my_id: AKIAIOSFODNN7EXAMPLE', False),
+            ('aws_secret_access_key: AKIAIOSFODNN7EXAMPLE', False),
+            ('aws_secret_access_key: not_secret_key', False),
+            ('some_other_40_char_base64_str: pARhvm1GmHyvLydUtFNCCMIIu4VEyaZNo9MbR3IJ', False),
+            ('some_secret_key=DcCc9H6oCkGUSp3Rhmsx8NIfVG8kO2T/3jORxuZY', True),
+            ('secret  =   wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY', True),
+            ('someGarbageInfront aws_secret: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY', True),
+            ('aws_thingy:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY', True),
+        ],
+    )
+    def test_analyze_line(self, payload, should_flag):
+        logic = AWSSSecretAccessKeyDetector()
+
+        output = logic.analyze_line(payload, 1, 'mock_filename')
+        assert len(output) == int(should_flag)


### PR DESCRIPTION
This PR creates a new detect-secrets plugin to discover AWS secret-access-keys. This differs from the previous aws rule which only looks for AWS _access key id_ s. These are not the secret portion of the credentials, and would be more prone to false positives.

Specifically, this check searches for a 40 character base64 encoded string that is prefixed by the phrases "aws", "secret", "access", or "key". 

Check the tests file to see some examples.